### PR TITLE
stop confetti drifting to the right

### DIFF
--- a/confetti.js
+++ b/confetti.js
@@ -195,7 +195,7 @@ var confetti = {
 				particle.y = height + 100;
 			else {
 				particle.tiltAngle += particle.tiltAngleIncrement;
-				particle.x += Math.sin(waveAngle);
+				particle.x += Math.sin(waveAngle) - 0.5;
 				particle.y += (Math.cos(waveAngle) + particle.diameter + confetti.speed) * 0.5;
 				particle.tilt = Math.sin(particle.tiltAngle) * 15;
 			}


### PR DESCRIPTION
The confetti drifted to the right as it fell down the screen, this PR fixes that.

I didn't run the minifier, because I wasn't sure what settings generated it.